### PR TITLE
Remove windows and macos test platforms

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        platform: [ubuntu-latest, windows-latest]
+        platform: [ubuntu-latest]
         python-version: [3.8, 3.9, '3.10']
 
     steps:


### PR DESCRIPTION
The windows platform is currently not working and macos may consume to much time/ressources in the available quota.